### PR TITLE
Add stripped log sawing/sawbuck recipes

### DIFF
--- a/InDappledGroves/assets/indappledgroves/recipes/ground/sawing/boards.json
+++ b/InDappledGroves/assets/indappledgroves/recipes/ground/sawing/boards.json
@@ -22,5 +22,17 @@
       }
     ],
     "output": {"type": "item", "code": "game:plank-{wood}", "quantity": 12}
+  },
+  {
+    "toolmode": "sawing",
+    "ingredients":
+    [ 
+      {"inputs": 
+       [
+         {"type": "block", "code": "indappledgroves:strippedlog-*-ud", "name": "wood", "states": ["aged"], "loadFromProperties": "block/wood"}
+       ]
+      }
+    ],
+    "output": {"type": "item", "code": "game:plank-{wood}", "quantity": 12}
   }
 ]

--- a/InDappledGroves/assets/indappledgroves/recipes/sawbuck/log.json
+++ b/InDappledGroves/assets/indappledgroves/recipes/sawbuck/log.json
@@ -22,5 +22,17 @@
       }
     ],
     "output": {"type": "item", "code": "game:plank-{wood}", "quantity": 12}
+  },
+  {
+    "toolmode": "sawing",
+    "ingredients":
+    [ 
+      {"inputs": 
+       [
+         {"type": "block", "code": "indappledgroves:strippedlog-*-ud", "name": "wood", "states": ["aged"], "loadFromProperties": "block/wood"}
+       ]
+      }
+    ],
+    "output": {"type": "item", "code": "game:plank-{wood}", "quantity": 12}
   }
 ]


### PR DESCRIPTION
When playing with the mod, we noticed that there were no recipes for sawing stripped logs. Assuming that's an oversight, this commit should fix it.