### PR TITLE
Fix missing langfile entry for tree hollow UI

### DIFF
--- a/InDappledGroves/assets/indappledgroves/lang/en.json
+++ b/InDappledGroves/assets/indappledgroves/lang/en.json
@@ -76,6 +76,7 @@ The bole of the hollow tree.</i></font>
 	"block-*-treehollowgrown-ebony-*": "Ebony Tree Hollow",
 	"block-*-treehollowgrown-walnut-*": "Walnut Tree Hollow",
 	"block-*-treehollowgrown-purpleheart-*": "Purpleheart Tree Hollow",
+	"treehollowcontents": "Tree Hollow Contents",
 
 
 	//Bark Basket Entries


### PR DESCRIPTION
The tree hollow inventory UI was missing a name.