### PR TITLE
Add CarryCapacity/CarryOn support to bark baskets

### DIFF
--- a/InDappledGroves/InDappledGroves.csproj
+++ b/InDappledGroves/InDappledGroves.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -97,6 +97,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="assets\indappledgroves\patches\ancienttools\log.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="assets\indappledgroves\patches\carryable\carryable.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="assets\indappledgroves\patches\idgvanilla\boardpatch.json">

--- a/InDappledGroves/assets/indappledgroves/patches/Carryable/carryable.json
+++ b/InDappledGroves/assets/indappledgroves/patches/Carryable/carryable.json
@@ -1,0 +1,58 @@
+[
+  { "file": "indappledgroves:blocktypes/barkbasket.json", "op": "add", "path": "/behaviors/-", "value": {
+    "name": "Carryable",
+    "properties": {
+      "interactDelay": 0.4,
+      "slots": {
+        "Hands": {
+          "animation": "carrycapacity:holdlight",
+          "walkSpeedModifier": -0.15
+        },
+        "Back": {
+          "walkSpeedModifier": 0.0,
+          "translation": [
+          0.09375,
+          0,
+          0.03125
+          ],
+          "rotation": [
+          0,
+          0,
+          -90
+          ],
+          "scale": 0.6
+        }
+      }
+    }
+  },
+  "dependsOn": [{ "modid": "carrycapacity" }, { "modid": "carryon", "invert": true }]
+  },
+  { "file": "indappledgroves:blocktypes/barkbasket.json", "op": "add", "path": "/behaviors/-", "value": {
+    "name": "Carryable",
+    "properties": {
+      "interactDelay": 0.4,
+      "slots": {
+        "Hands": {
+          "animation": "carrycapacity:holdlight",
+          "walkSpeedModifier": -0.15
+        },
+        "Back": {
+          "walkSpeedModifier": 0.0,
+          "translation": [
+          0.09375,
+          0,
+          0.03125
+          ],
+          "rotation": [
+          0,
+          0,
+          -90
+          ],
+          "scale": 0.6
+        }
+      }
+    }
+  },
+  "dependsOn": [{ "modid": "carryon" }]
+  }
+]


### PR DESCRIPTION
Settings copied from the CarryOn/CarryCapacity support for vanilla stationary bark baskets.

Note: While CarryCapacity is *deprecated,* it still works, and many mods like CraluTweaks support it but not the new fork, CarryOn. I would suggest supporting both mods (like this does) until CarryCapacity actually breaks with an update.