### PR TITLE
Fix tree generation Harmony patch

### DIFF
--- a/InDappledGroves/Util/HarmonyPatches/TreeGenPatch.cs
+++ b/InDappledGroves/Util/HarmonyPatches/TreeGenPatch.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -40,11 +40,11 @@ namespace InDappledGroves.Util.HarmonyPatches
             codeMatcher.Insert(
                 new CodeInstruction(OpCodes.Ldarg_0), // Put "argument 0" (`this`) on stack, so that the next instruction can use it
                 CodeInstruction.LoadField(typeof(TreeGen), "blockAccessor"), // Load the BlockAccessor used by the tree generator itself
-                new CodeInstruction(OpCodes.Ldarg_2), // Load 2nd argument of the method we are patching (`BlockPos pos`)
-                new CodeInstruction(OpCodes.Ldloc_S, 9), // Load method local variable #10 (`int iteration`) 
-                new CodeInstruction(OpCodes.Ldloc_S, 21), // Load method local variable #22 (`int blockId`)
-                new CodeInstruction(OpCodes.Ldloc_S, 11), // Load method local variable #17 (`BlockPos currentPos`) 
-                new CodeInstruction(OpCodes.Ldarg, 12), //Load local argument #12 ('WideTrunk')
+                new CodeInstruction(OpCodes.Ldarg_2), // Load 2nd argument of the method we are patching (`int depth`)
+                new CodeInstruction(OpCodes.Ldloc_S, 10), // Load method local variable #11 (`int iteration`) 
+                new CodeInstruction(OpCodes.Ldloc_S, 22), // Load method local variable #23 (`int blockId`)
+                new CodeInstruction(OpCodes.Ldloc_S, 17), // Load method local variable #18 (`BlockPos currentPos`) 
+                new CodeInstruction(OpCodes.Ldarg, 13), //Load local argument #14 ('bool WideTrunk')
                 CodeInstruction.Call(typeof(HarmonyModSystem), "GrowBranchTranspilerCall")
             );
 


### PR DESCRIPTION
The arguments for `GrowBranchTranspilerCall` were wrong.
<details>
  <summary>Local variable list</summary>

```cil
	.locals init (
		[0] class Vintagestory.ServerMods.NoObf.TreeGenBranch branch,
		[1] float32 widthloss,
		[2] float32 widthlossCurve,
		[3] float32 branchspacing,
		[4] float32 branchstart,
		[5] float32 branchQuantityStart,
		[6] float32 branchWidthMulitplierStart,
		[7] float32 reldistance,
		[8] float32 lastreldistance,
		[9] float32 totaldistance,
		[10] int32 iteration,
		[11] float32 sequencesPerIteration,
		[12] float32 ddrag,
		[13] float32 angleVer,
		[14] float32 angleHor,
		[15] float32 trunkOffsetX,
		[16] float32 trunkOffsetZ,
		[17] class [VintagestoryAPI]Vintagestory.API.MathTools.BlockPos currentPos,
		[18] float32 sinAngleVer,
		[19] float32 cosAnglerHor,
		[20] float32 sinAngleHor,
		[21] float32 currentSequence,
		[22] int32 blockId,
		[23] valuetype Vintagestory.ServerMods.PlaceResumeState state,
		[24] float32 branchQuantity
	)
```
</details>

We were passing `float totalDistance` instead of `int iteration`, `float currentSequence` instead of `int blockId`, and `float sequencesPerIteration` instead of `BlockPos currentPos`.
<details>
  <summary>Arguments list</summary>

```cil
		class Vintagestory.ServerMods.TreeGen this,
		class [System.Runtime]System.Random rand,
		int32 depth,
		class [VintagestoryAPI]Vintagestory.API.MathTools.BlockPos basePos,
		int32 treeSubType,
		float32 dx,
		float32 dy,
		float32 dz,
		float32 angleVerStart,
		float32 angleHorStart,
		float32 curWidth,
		float32 dieAt,
		float32 trunkWidthLoss,
		bool wideTrunk
```
</details>

We also passed `float trunkWidthLoss` instead of `bool wideTrunk`. Now, everything should line up.
<details>
  <summary>Screenshots</summary>

![image](https://github.com/Aetherial-Labs/InDappledGroves/assets/101909198/f6ab48e7-c386-4e66-bc41-50eed7bee1aa)
![image](https://github.com/Aetherial-Labs/InDappledGroves/assets/101909198/34ec0f39-6282-4789-a2f5-6c5d23f2e78b)
![image](https://github.com/Aetherial-Labs/InDappledGroves/assets/101909198/deff274d-2fc0-4b7a-a5e2-a958fdf75d71)
</details>